### PR TITLE
closes #41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
+package-lock.json
 public/bundle.js
 .DS_Store


### PR DESCRIPTION
@leafoflegend do you think we should remove package-lock.json from entire git history? or is it enough to just ignore for future commits?