### PR TITLE
Rename syncAndSeed function 

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ app.use(express.static(path.join(__dirname, '.', 'public')))
 
 app.use('/api', require('./api'))
 
-db.syncAndSeed()
+db.syncSeed()
 
 const PORT = process.env.PORT || 3000
 


### PR DESCRIPTION
Accidentally wrote it as syncSeed in all of my previous commits, so I changed it in server.js