### PR TITLE
product methods for search and filter added

### DIFF
--- a/api/products.js
+++ b/api/products.js
@@ -10,9 +10,7 @@ const checkAdmin = require('./checkAdmin')
 //Get all products
 router.get('/', async (req, res, next) => {
     try {
-        let products = await db.Product.findAll({
-            include: [db.Category]
-        })
+        let products = await db.Product.getActiveProducts()
         res.send(products)
     } catch (ex) {
         next(ex)
@@ -43,6 +41,15 @@ router.get('/category/:id', async (req, res, next) => {
     }
 })
 
+router.get('/search/:search', async (req, res, next) => {
+    try {
+        let searchArr = await db.Product.searchTitle(req.params.search)
+        res.send(searchArr)
+    } catch (ex) {
+        next(ex)
+    }
+
+})
 //AUTH ROUTES
 
 //Auth Middleware

--- a/db/index.js
+++ b/db/index.js
@@ -70,6 +70,12 @@ const syncSeed = async () => {
                 price: 300,
                 quantity: 33
             })
+            const discontinuedCelery = await Product.create({
+                title: 'Discontinued Celery',
+                description: 'Users should not see this while browsing or searching',
+                price: 400,
+                quantity: 0
+            })
             const lex = await User.create({
                 email: 'lex@email.com',
                 password: '123',

--- a/db/models/Product.js
+++ b/db/models/Product.js
@@ -1,6 +1,8 @@
 const Seq = require('sequelize');
 const conn = require('../connection');
 
+const Category = require('./Category')
+
 const Product = conn.define('product', {
     title: {
         type: Seq.STRING,
@@ -24,5 +26,34 @@ const Product = conn.define('product', {
         defaultValue: '/default.png'
     }
 })
+
+Product.searchTitle = async function(searchTerm){
+    searchTerm = searchTerm.toLowerCase()
+    let totalArr = await Product.findAll({
+        include: [Category]
+    })
+    let searchArr = []
+
+    totalArr.forEach( elem => {
+        if (elem.title.toLowerCase().indexOf(searchTerm) !== -1 && elem.quantity > 0){
+            searchArr.push(elem)
+        }
+    })
+    return searchArr
+}
+
+Product.getActiveProducts = async function(){
+    let totalArr = await Product.findAll({
+        include: [Category]
+    })
+    let activeArr = []
+
+    totalArr.forEach( elem => {
+        if (elem.quantity > 0){
+            activeArr.push(elem)
+        }
+    })
+    return activeArr
+}
 
 module.exports = Product


### PR DESCRIPTION
Added methods to the Product model and updated the api to get the below functionality:

Search for a product:
Send a GET to 'api/product/search/:searchTerm', and it'll run Product.searchTitle(searchTerm) and send the results (the product instances) in an array. Will only return product that has the search term in the name and quantity > 0.

Users browsing the store should only see products with inventory:
A GET to 'api/product' now returns Product.getActiveProducts() -not Product.findAll()- and sends that back. If a user's cart needs to access data on an item they previously ordered, the get product by id route ('/api/products/:id') will still send the data for discontinued items

Added in a "discontinued celery" product with inventory of 0 into the seed data just to test if everything works 