### PR TITLE
server error handling, oauth throw error added

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -58,7 +58,7 @@ router.get('/facebook/callback', async (req, res, next) => {
 
     response = await axios.get(`https://graph.facebook.com/me?fields=email&access_token=${access_token}`)
     let facebookData = response.data
-    console.log(facebookData)
+    //console.log(facebookData)
 
     let user = await User.findOne({
       where: {
@@ -66,7 +66,7 @@ router.get('/facebook/callback', async (req, res, next) => {
       }
     })
     if (!user){
-      res.redirect('/sign-up')
+      return next(new Error('User account not found'))
     }
     const token = jwt.encode({id: user.id}, process.env.JWT_SECRET)
     res.send({token})

--- a/api/products.js
+++ b/api/products.js
@@ -41,6 +41,7 @@ router.get('/category/:id', async (req, res, next) => {
     }
 })
 
+//Search products by Title
 router.get('/search/:search', async (req, res, next) => {
     try {
         let searchArr = await db.Product.searchTitle(req.params.search)

--- a/server.js
+++ b/server.js
@@ -17,3 +17,7 @@ app.listen(PORT, () => {
     console.log(`Now listening in on port ${PORT}`)
 })
 
+app.use( (err, req, res, next) => {
+    console.log("Express is handling error: ", err)
+    res.status(err.status || 500).send({ error: err.message })
+})


### PR DESCRIPTION
- Added server error handling

- Facebook OAuth route will now throw an error to the error handler if the fb user is not found in our user db. We're not able to create the user in our db if they're not found as the fb api doesn't give us access to their password. (May want to have the front end display the error and re-direct back to the login page in that case, or to the sign up page and have the user enter their password there?) 

- Product search api route was missing a label, added it in