### PR TITLE
tweak ouauth api and order db

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -62,11 +62,19 @@ router.get('/facebook/callback', async (req, res, next) => {
 
     let user = await User.findOne({
       where: {
-        facebookEmail: facebookData.email
+        email: facebookData.email
       }
     })
     if (!user){
-      return next(new Error('User account not found'))
+      if (facebookData.email){
+        user = User.create({
+          email: facebookData.email,
+          passowrd: '',
+          isAdmin: false
+        })
+      } else {
+      return next(new Error('Facebook User Validation Failed.'))
+      }
     }
     const token = jwt.encode({id: user.id}, process.env.JWT_SECRET)
     res.send({token})

--- a/api/lineitems.js
+++ b/api/lineitems.js
@@ -91,8 +91,7 @@ router.put('/:id', async (req, res, next) => {
         if ((reqUser !== lineItem.dataValues.userId) && (!await checkAdmin(reqUser))) {
             return res.sendStatus(401)
         }
-        let editedLineItem = await db.LineItem.findById(req.params.id)
-        await editedLineItem.update(req.body)
+        await lineItem.update(req.body)
         res.send(lineItem)
     } catch (ex) {
         next(ex)

--- a/db/index.js
+++ b/db/index.js
@@ -94,10 +94,9 @@ const syncSeed = async () => {
                 productId: choppedCelery.id
             })
             const lex = await User.create({
-                email: 'lex@email.com',
+                email: 'lexbedwell@gmail.com',
                 password: '123',
-                isAdmin: true,
-                facebookEmail: 'lexbedwell@gmail.com'
+                isAdmin: true
             })
             const sam = await User.create({
                 email: 'sam@email.com',
@@ -134,7 +133,6 @@ const syncSeed = async () => {
             await choppedCelery.addReview(chopRev2);
         })
 }
-
 
 module.exports = {
     syncSeed,

--- a/db/models/Order.js
+++ b/db/models/Order.js
@@ -11,6 +11,26 @@ const Order = conn.define('order', {
       type: conn.Sequelize.ENUM('cart', 'created', 'processing', 'cancelled', 'completed', 'delivered'),
       allowNull: false,
       defaultValue: 'cart'
+    },
+    addressName: {
+      type: Seq.STRING,
+      allowNull: true
+    },
+    addressLine: {
+      type: Seq.STRING,
+      allowNull: true
+    },
+    addressCity: {
+      type: Seq.STRING,
+      allowNull: true
+    },
+    addressState: {
+      type: Seq.STRING,
+      allowNull: true
+    },
+    addressZip: {
+      type: Seq.STRING,
+      allowNull: true
     }
 });
 

--- a/db/models/User.js
+++ b/db/models/User.js
@@ -11,21 +11,11 @@ const User = conn.define('user', {
   },
   password: {
     type: Seq.STRING,
-    allowNull: false,
-    validate: {
-      notEmpty: true
-    }
+    allowNull: true
   },
   isAdmin: {
     type: Seq.BOOLEAN,
     defaultValue: false
-  },
-  facebookEmail: {
-    type: Seq.STRING,
-    unique: true,
-    validate: {
-      isEmail: true,
-    }
   }
 });
 


### PR DESCRIPTION
- Oauth now creates the fb user in our db if their email address is not found, with user model modified (remove fb email field, allow empty password) to allow this

- Orders model now has address fields added in. Allows carts to be created with no address info entered, so address validation would happen on front end 